### PR TITLE
Add codecov : test coverage

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -54,4 +54,11 @@ jobs:
         run: dart run tool/locale/check_localizations.dart
 
       - name: Run tests
-        run: flutter test --no-pub
+        run: flutter test --no-pub --coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FoodSavr
 
+ [![Format, Analyze, Check Localizations and Run Tests](https://github.com/JoachimTislov/foodsavr/actions/workflows/ci-checks.yml/badge.svg)](https://github.com/JoachimTislov/foodsavr/actions/workflows/ci-checks.yml) [![codecov](https://codecov.io/gh/JoachimTislov/foodsavr/graph/badge.svg?token=R6TX2180SE)](https://codecov.io/gh/JoachimTislov/foodsavr)
+
 `Foodsavr` is a mobile application designed to help you reduce food 
 waste, save time, and manage your grocery expenses efficiently. By tracking 
 inventory and synchronizing with your meal planning, the application ensures you always know 


### PR DESCRIPTION
Badge in README, process report after test run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI status and code coverage badges to the project README.

* **Tests**
  * Automated test runs now generate code coverage reports.
  * Coverage results are uploaded to Codecov, with CI reporting upload failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->