### PR TITLE
chore: add watch_it dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   easy_localization: ^3.0.0 # MIT
   logger: ^2.6.2 # MIT
   get_it: ^9.2.0 # MIT
+  watch_it: ^2.4.2 # MIT
   intl: ^0.20.2 # BSD-3-Clause
   google_sign_in: ^7.2.0 # BSD-3-Clause
   flutter_facebook_auth: ^7.1.5 # MIT


### PR DESCRIPTION
Adds the watch_it package to pubspec.yaml to enable reactive state management, as per Issue #29. This is a chore as it updates a dependency.