### PR TITLE
fix(router): isolate auth flow tests and add missing cases

### DIFF
--- a/test/router_auth_flow_redirect_test.dart
+++ b/test/router_auth_flow_redirect_test.dart
@@ -1,0 +1,273 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'dart:async';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:foodsavr/interfaces/i_auth_service.dart';
+import 'package:foodsavr/routes/go_router.dart';
+import 'package:foodsavr/service_locator.dart';
+import 'package:foodsavr/controllers/c_auth.dart';
+import 'package:foodsavr/services/product_service.dart';
+import 'package:foodsavr/interfaces/i_product_repository.dart';
+import 'package:foodsavr/interfaces/i_collection_repository.dart'; // Explicitly import ICollectionRepository
+import 'package:foodsavr/models/product_model.dart';
+import 'package:foodsavr/models/collection_model.dart'; // Import Collection
+import 'package:foodsavr/views/landing_page_view.dart';
+import 'package:foodsavr/views/dashboard_view.dart';
+import 'package:foodsavr/services/collection_service.dart'; // Import CollectionService
+import 'package:foodsavr/utils/shelf_life.dart';
+import 'package:foodsavr/utils/theme_notifier.dart';
+import 'package:go_router/go_router.dart';
+import 'package:logger/logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+class _MockShelfLifeService extends Mock implements ShelfLifeService {}
+
+class _FakeCollectionRepository implements ICollectionRepository {
+  @override
+  Future<Collection> add(Collection entity) async => entity;
+
+  @override
+  Future<Collection?> get(String id) async => null;
+
+  @override
+  Future<List<Collection>> getAll() async => [];
+
+  @override
+  Future<void> update(Collection entity) async {}
+
+  @override
+  Future<void> delete(String id) async {}
+
+  @override
+  Future<List<Collection>> getCollections(String userId) async => [];
+
+  @override
+  Future<void> addProduct(String collectionId, String productId) async {}
+
+  @override
+  Future<void> addProducts(
+    String collectionId,
+    List<String> productIds,
+  ) async {}
+
+  @override
+  Future<void> removeProduct(String collectionId, String productId) async {}
+}
+
+class _MockUser extends Mock implements User {}
+
+class _MockUserCredential extends Mock implements UserCredential {}
+
+class _FakeProductRepository implements IProductRepository {
+  @override
+  Future<Product> add(Product entity) async => entity;
+  @override
+  Future<Product?> get(String id) async => null;
+  @override
+  Future<void> update(Product entity) async {}
+  @override
+  Future<void> delete(String id) async {}
+  @override
+  Future<List<Product>> getAll() async => [];
+  @override
+  Future<List<Product>> getProducts(String userId) async => [];
+  @override
+  Future<List<Product>> getPersonalProducts(String userId) async => [];
+  @override
+  Future<List<Product>> getGlobalProducts() async => [];
+}
+
+class _FakeAuthService implements IAuthService {
+  late final StreamController<User?> _controller =
+      StreamController<User?>.broadcast(
+        onListen: () {
+          _controller.add(_userId != null ? _MockUser() : null);
+        },
+      );
+  String? _userId;
+
+  void signInForTest(String userId) {
+    _userId = userId;
+    _controller.add(_MockUser());
+  }
+
+  @override
+  Stream<User?> get authStateChanges => _controller.stream;
+
+  @override
+  User? get currentUser => _userId != null ? _MockUser() : null;
+
+  @override
+  String? getUserId() => _userId;
+  @override
+  Future<UserCredential> signIn({
+    required String email,
+    required String password,
+    bool rememberMe = false,
+  }) async {
+    signInForTest('test-user');
+    return _MockUserCredential();
+  }
+
+  @override
+  Future<UserCredential> signUp({
+    required String email,
+    required String password,
+  }) async {
+    signInForTest('test-user');
+    return _MockUserCredential();
+  }
+
+  @override
+  Future<void> signOut() async {
+    _userId = null;
+    _controller.add(null);
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+
+  @override
+  Future<UserCredential> signInWithFacebook() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserCredential> signInWithGoogle() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserCredential> signInAsGuest() {
+    signInForTest('test-user');
+    return Future.value(_MockUserCredential());
+  }
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) {
+    throw UnimplementedError();
+  }
+}
+
+class _TestApp extends StatelessWidget {
+  final GoRouter router;
+
+  const _TestApp({required this.router});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      localizationsDelegates: context.localizationDelegates,
+      supportedLocales: context.supportedLocales,
+      locale: context.locale,
+      routerConfig: router,
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  EasyLocalization.logger.enableBuildModes = [];
+  EasyLocalization.logger.enableLevels = [];
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMessageHandler('flutter/lifecycle', (_) async => null);
+
+  group('Auth routing regression', () {
+    late _FakeAuthService authService;
+    late GoRouter router;
+
+    setUp(() async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({});
+      final prefs = await SharedPreferencesWithCache.create(
+        cacheOptions: const SharedPreferencesWithCacheOptions(),
+      );
+      SharedPreferences.setMockInitialValues({});
+      await EasyLocalization.ensureInitialized();
+      await getIt.reset();
+
+      getIt.registerSingleton<SharedPreferencesWithCache>(prefs);
+      getIt.registerSingleton<ThemeNotifier>(ThemeNotifier(prefs));
+
+      authService = _FakeAuthService();
+      router = createAppRouter(authService);
+      getIt.registerLazySingleton<IAuthService>(() => authService);
+      getIt.registerLazySingleton<ProductService>(
+        () => ProductService(
+          _FakeProductRepository(),
+          _MockShelfLifeService(),
+          Logger(level: Level.off),
+        ),
+      );
+      getIt.registerLazySingleton<CollectionService>(
+        () => CollectionService(
+          _FakeCollectionRepository(),
+          Logger(level: Level.off),
+        ),
+      );
+      getIt.registerFactory<AuthController>(
+        () => AuthController(
+          getIt<IAuthService>(),
+          Logger(level: Level.off),
+          translate: (String key) => key,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      router.dispose();
+      await authService.dispose();
+      await getIt.reset();
+    });
+
+    testWidgets(
+      'redirects authenticated user from landing to dashboard',
+      (tester) async {
+        final originalOnError = FlutterError.onError;
+        FlutterError.onError = (details) {
+          final message = details.exceptionAsString();
+          if (message.contains('A RenderFlex overflowed')) {
+            return;
+          }
+          originalOnError?.call(details);
+        };
+        addTearDown(() {
+          FlutterError.onError = originalOnError;
+        });
+
+        tester.view.physicalSize = const Size(1400, 2200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        authService.signInForTest('uid-123');
+
+        await tester.pumpWidget(
+          EasyLocalization(
+            supportedLocales: const [Locale('en'), Locale('nb')],
+            path: 'assets/translations',
+            fallbackLocale: const Locale('en'),
+            child: _TestApp(router: router),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DashboardView), findsOneWidget);
+        expect(find.byType(LandingPageView), findsNothing);
+      },
+    );
+  });
+
+  tearDownAll(() {
+    messenger.setMockMessageHandler('flutter/lifecycle', null);
+  });
+}

--- a/test/router_auth_flow_sign_out_test.dart
+++ b/test/router_auth_flow_sign_out_test.dart
@@ -1,0 +1,278 @@
+// ignore_for_file: depend_on_referenced_packages
+
+import 'dart:async';
+
+import 'package:easy_localization/easy_localization.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:foodsavr/interfaces/i_auth_service.dart';
+import 'package:foodsavr/routes/go_router.dart';
+import 'package:foodsavr/service_locator.dart';
+import 'package:foodsavr/controllers/c_auth.dart';
+import 'package:foodsavr/services/product_service.dart';
+import 'package:foodsavr/interfaces/i_product_repository.dart';
+import 'package:foodsavr/interfaces/i_collection_repository.dart'; // Explicitly import ICollectionRepository
+import 'package:foodsavr/models/product_model.dart';
+import 'package:foodsavr/models/collection_model.dart'; // Import Collection
+import 'package:foodsavr/views/landing_page_view.dart';
+import 'package:foodsavr/views/dashboard_view.dart';
+import 'package:foodsavr/services/collection_service.dart'; // Import CollectionService
+import 'package:foodsavr/utils/shelf_life.dart';
+import 'package:foodsavr/utils/theme_notifier.dart';
+import 'package:go_router/go_router.dart';
+import 'package:logger/logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/in_memory_shared_preferences_async.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_async_platform_interface.dart';
+
+class _MockShelfLifeService extends Mock implements ShelfLifeService {}
+
+class _FakeCollectionRepository implements ICollectionRepository {
+  @override
+  Future<Collection> add(Collection entity) async => entity;
+
+  @override
+  Future<Collection?> get(String id) async => null;
+
+  @override
+  Future<List<Collection>> getAll() async => [];
+
+  @override
+  Future<void> update(Collection entity) async {}
+
+  @override
+  Future<void> delete(String id) async {}
+
+  @override
+  Future<List<Collection>> getCollections(String userId) async => [];
+
+  @override
+  Future<void> addProduct(String collectionId, String productId) async {}
+
+  @override
+  Future<void> addProducts(
+    String collectionId,
+    List<String> productIds,
+  ) async {}
+
+  @override
+  Future<void> removeProduct(String collectionId, String productId) async {}
+}
+
+class _MockUser extends Mock implements User {}
+
+class _MockUserCredential extends Mock implements UserCredential {}
+
+class _FakeProductRepository implements IProductRepository {
+  @override
+  Future<Product> add(Product entity) async => entity;
+  @override
+  Future<Product?> get(String id) async => null;
+  @override
+  Future<void> update(Product entity) async {}
+  @override
+  Future<void> delete(String id) async {}
+  @override
+  Future<List<Product>> getAll() async => [];
+  @override
+  Future<List<Product>> getProducts(String userId) async => [];
+  @override
+  Future<List<Product>> getPersonalProducts(String userId) async => [];
+  @override
+  Future<List<Product>> getGlobalProducts() async => [];
+}
+
+class _FakeAuthService implements IAuthService {
+  late final StreamController<User?> _controller =
+      StreamController<User?>.broadcast(
+        onListen: () {
+          _controller.add(_userId != null ? _MockUser() : null);
+        },
+      );
+  String? _userId;
+
+  void signInForTest(String userId) {
+    _userId = userId;
+    _controller.add(_MockUser());
+  }
+
+  @override
+  Stream<User?> get authStateChanges => _controller.stream;
+
+  @override
+  User? get currentUser => _userId != null ? _MockUser() : null;
+
+  @override
+  String? getUserId() => _userId;
+  @override
+  Future<UserCredential> signIn({
+    required String email,
+    required String password,
+    bool rememberMe = false,
+  }) async {
+    signInForTest('test-user');
+    return _MockUserCredential();
+  }
+
+  @override
+  Future<UserCredential> signUp({
+    required String email,
+    required String password,
+  }) async {
+    signInForTest('test-user');
+    return _MockUserCredential();
+  }
+
+  @override
+  Future<void> signOut() async {
+    _userId = null;
+    _controller.add(null);
+  }
+
+  Future<void> dispose() async {
+    await _controller.close();
+  }
+
+  @override
+  Future<UserCredential> signInWithFacebook() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserCredential> signInWithGoogle() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<UserCredential> signInAsGuest() {
+    signInForTest('test-user');
+    return Future.value(_MockUserCredential());
+  }
+
+  @override
+  Future<void> sendPasswordResetEmail(String email) {
+    throw UnimplementedError();
+  }
+}
+
+class _TestApp extends StatelessWidget {
+  final GoRouter router;
+
+  const _TestApp({required this.router});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp.router(
+      localizationsDelegates: context.localizationDelegates,
+      supportedLocales: context.supportedLocales,
+      locale: context.locale,
+      routerConfig: router,
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  EasyLocalization.logger.enableBuildModes = [];
+  EasyLocalization.logger.enableLevels = [];
+  final messenger =
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+  messenger.setMockMessageHandler('flutter/lifecycle', (_) async => null);
+
+  group('Auth routing regression', () {
+    late _FakeAuthService authService;
+    late GoRouter router;
+
+    setUp(() async {
+      SharedPreferencesAsyncPlatform.instance =
+          InMemorySharedPreferencesAsync.withData({});
+      final prefs = await SharedPreferencesWithCache.create(
+        cacheOptions: const SharedPreferencesWithCacheOptions(),
+      );
+      SharedPreferences.setMockInitialValues({});
+      await EasyLocalization.ensureInitialized();
+      await getIt.reset();
+
+      getIt.registerSingleton<SharedPreferencesWithCache>(prefs);
+      getIt.registerSingleton<ThemeNotifier>(ThemeNotifier(prefs));
+
+      authService = _FakeAuthService();
+      router = createAppRouter(authService);
+      getIt.registerLazySingleton<IAuthService>(() => authService);
+      getIt.registerLazySingleton<ProductService>(
+        () => ProductService(
+          _FakeProductRepository(),
+          _MockShelfLifeService(),
+          Logger(level: Level.off),
+        ),
+      );
+      getIt.registerLazySingleton<CollectionService>(
+        () => CollectionService(
+          _FakeCollectionRepository(),
+          Logger(level: Level.off),
+        ),
+      );
+      getIt.registerFactory<AuthController>(
+        () => AuthController(
+          getIt<IAuthService>(),
+          Logger(level: Level.off),
+          translate: (String key) => key,
+        ),
+      );
+    });
+
+    tearDown(() async {
+      router.dispose();
+      await authService.dispose();
+      await getIt.reset();
+    });
+
+    testWidgets(
+      'redirects to landing after sign out',
+      (tester) async {
+        final originalOnError = FlutterError.onError;
+        FlutterError.onError = (details) {
+          final message = details.exceptionAsString();
+          if (message.contains('A RenderFlex overflowed')) {
+            return;
+          }
+          originalOnError?.call(details);
+        };
+        addTearDown(() {
+          FlutterError.onError = originalOnError;
+        });
+
+        tester.view.physicalSize = const Size(1400, 2200);
+        tester.view.devicePixelRatio = 1.0;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+
+        authService.signInForTest('uid-123');
+
+        await tester.pumpWidget(
+          EasyLocalization(
+            supportedLocales: const [Locale('en'), Locale('nb')],
+            path: 'assets/translations',
+            fallbackLocale: const Locale('en'),
+            child: _TestApp(router: router),
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        expect(find.byType(DashboardView), findsOneWidget);
+
+        await authService.signOut();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(LandingPageView), findsOneWidget);
+        expect(find.byType(DashboardView), findsNothing);
+      },
+    );
+  });
+
+  tearDownAll(() {
+    messenger.setMockMessageHandler('flutter/lifecycle', null);
+  });
+}


### PR DESCRIPTION
Splits the router authentication flow tests into isolated files to prevent state leakage and adds new test cases for authenticated redirects and sign-out behavior, addressing the GoRouter test isolation bug in Issue #66.